### PR TITLE
Add all-contributors and codeowners

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,14 @@
+{
+  "projectName": "github-pull-request-script",
+  "projectOwner": "vtex",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "none",
+  "contributors": [],
+  "contributorsPerLine": 7
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @vtex-apps/store-framework-devs
+docs/ @vtex-apps/technical-writers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update .all-contributorsrc file

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Github Pull Request Script
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This script automates the process of creating pull requests with specific changes in multiple repositories.
 
@@ -48,3 +51,16 @@ Every task should return `undefined` or an object containing:
   - `value` - the message of this change log entry
 
 The `process.cwd()` is changed for each repository being currently worked on. This way you can use the current working directory to resolve files from the root of each repository.
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
This automated pull request aims to:

- Add `all-contributors` to the project.
- Add `CODEOWNERS` with mentions to the store-framework dev team and the tech-writers team for `docs` changes.