### PR TITLE
Add warning when Github token is missing

### DIFF
--- a/script/index.ts
+++ b/script/index.ts
@@ -31,14 +31,15 @@ async function main() {
     log(`Running in dry-run mode. The script won't push and create PRs.`, {
       color: 'yellow',
     })
-  } else if (!CONFIG.dryRun && CONFIG.githubToken === undefined) {
+  } else if (!CONFIG.dryRun && CONFIG.githubToken == null) {
     log(
-      'No Github token found. Branches will be created, but all pull requests will fail.',
+      'No Github token found. Make sure to define it in your "config.ts" file',
       {
-        type: 'warn',
-        color: 'yellow',
+        type: 'error',
+        color: 'red',
       }
     )
+    process.exit(1)
   }
 
   const repoURLs = repos.map(repo => `git@github.com:${repo}.git`)

--- a/script/index.ts
+++ b/script/index.ts
@@ -31,6 +31,14 @@ async function main() {
     log(`Running in dry-run mode. The script won't push and create PRs.`, {
       color: 'yellow',
     })
+  } else if (!CONFIG.dryRun && CONFIG.githubToken === undefined) {
+    log(
+      'No Github token found. Branches will be created, but all pull requests will fail.',
+      {
+        type: 'warn',
+        color: 'yellow',
+      }
+    )
   }
 
   const repoURLs = repos.map(repo => `git@github.com:${repo}.git`)


### PR DESCRIPTION
This can prevent silly mistakes 👀

Maybe other way to handle this problem would be improving the error log message when this happens. Example bellow when I forgot to add the GH token.

![image](https://user-images.githubusercontent.com/26108090/81769407-e88f8c80-94b3-11ea-9720-30dcf8c52264.png)
