### PR TITLE
Improve codeowners task: fix a bug and allow multiple globs per team

### DIFF
--- a/script/tasks/codeowners.ts
+++ b/script/tasks/codeowners.ts
@@ -4,10 +4,12 @@ import { TaskFunction } from '../types'
 import { resolvePathCurrentRepo } from '../modules/repo'
 import { log } from '../modules/Logger'
 
-const CODEOWNERS = {
-  '@vtex-apps/store-framework-devs': '*',
-  '@vtex-apps/technical-writers': 'docs/',
-}
+const CODEOWNERS: Array<[string, string]> = [
+  ['@vtex-apps/store-framework-devs', '*'],
+  ['@vtex-apps/technical-writers', 'docs/'],
+  ['@vtex-apps/localization', 'messages/'],
+  ['@vtex-apps/localization', 'src/i18n/'],
+]
 
 const task: TaskFunction = async () => {
   let updatedDir = false
@@ -60,7 +62,7 @@ const task: TaskFunction = async () => {
       return acc
     }, {})
 
-  for (const [team, glob] of Object.entries(CODEOWNERS)) {
+  for (const [team, glob] of CODEOWNERS) {
     if (glob in parsedContent) {
       if (!parsedContent[glob].includes(team)) {
         parsedContent[glob].push(team)

--- a/script/tasks/codeowners.ts
+++ b/script/tasks/codeowners.ts
@@ -20,11 +20,27 @@ const task: TaskFunction = async () => {
   fs.ensureDirSync(resolvePathCurrentRepo('.github'))
 
   if (fs.pathExistsSync(rootFilePath)) {
-    commitMessages.push('Moved CODEOWNERS to .github/')
+    if (fs.pathExistsSync(ghFilePath)) {
+      commitMessages.push('Appended CODEOWNERS to .github/CODEOWNERS')
+      log(`Appending CODEOWNERS to .github/CODEOWNERS`, {
+        indent: 2,
+        color: 'green',
+      })
 
-    log(`Moving CODEOWNERS to .github/`, { indent: 2, color: 'green' })
+      const rootFileContent: string = await fs
+        .readFile(rootFilePath, { encoding: 'utf-8' })
+        .then(str => str.trim())
+        .catch(() => '')
 
-    fs.moveSync(rootFilePath, ghFilePath)
+      await fs.appendFile(ghFilePath, rootFileContent)
+      await fs.unlink(rootFilePath)
+    } else {
+      commitMessages.push('Moved CODEOWNERS to .github/')
+      log(`Moving CODEOWNERS to .github/`, { indent: 2, color: 'green' })
+
+      fs.moveSync(rootFilePath, ghFilePath)
+    }
+
     updatedDir = true
   }
 


### PR DESCRIPTION
This fixes a bug where the codeowners task checks if a CODEOWNERS file exists in the root directory and moves it to `.github/`. If a `.github/CODEOWNERS` file already exists, it will fail to move and crash. This scenario happens on [vtex-apps/location-availability](https://github.com/vtex-apps/location-availability/tree/ebbed0e3d9cee0700dd6b60639e14d24a475b088).

Also, this PR adds the possibility of having multiple globs per team.

Test plan:
- download this branch
- change the whole content of `config/lists/sf-repos.json` to `["vtex-apps/location-availability"]`
- enable `taskCodeOwners` in `config/config.ts` (basically change the boolean on line 31)
- run `yarn go --dry-run`
- run `cat .tmp/vtex-apps_location-availability/CODEOWNERS`. It should display an error: `cat: .tmp/vtex-apps_location-availability/CODEOWNERS: No such file or directory`
- run `cat .tmp/vtex-apps_location-availability/.github/CODEOWNERS`. It should print a text equal to:

```
docs/ @vtex-apps/technical-writers
* @vtex-apps/us-1st-party-apps @vtex-apps/store-framework-devs
messages/ @vtex-apps/localization
src/i18n/ @vtex-apps/localization
```